### PR TITLE
feat(roots-cognito): Adds ensureExternalUserExists to PreSignUp handler

### DIFF
--- a/examples/javascript/src/lib/jane-service.mjs
+++ b/examples/javascript/src/lib/jane-service.mjs
@@ -22,6 +22,25 @@ const createUser = async (data, token) => {
   }
 }
 
+// /** ----- ENSURE EXTERNAL USER ----- */
+// export interface ExternalUserData {
+//   email: string,
+//   external_id: string,
+//   pool_id: string,
+//   user_attributes?: {
+//     [key: string]: any // eslint-disable-line @typescript-eslint/no-explicit-any
+//   }
+// }
+
+const ensureExternalUserExists = async (data) => {
+  const response = await apiService.post(`${COGNITO_API}/ensure_external_user_exists`, data)
+
+  return {
+    success: response.statusCode === 200,
+    errorMessage: response.statusMessage,
+  }
+}
+
 /** ----- USER EXISTS ----- */
 
 const userExists = async (data, token) => {
@@ -149,6 +168,7 @@ export default {
   createUser,
   getAppClient,
   userExists,
+  ensureExternalUserExists,
   verifyCredentials,
   validateUser
 }

--- a/examples/javascript/src/lib/jane-service.spec.mjs
+++ b/examples/javascript/src/lib/jane-service.spec.mjs
@@ -248,6 +248,48 @@ describe('jane service', () => {
     })
   })
 
+  describe('#ensureExternalUserExists', () => {
+    test('returns valid when the status code is 200', async () => {
+      jest.spyOn(apiService, 'post').mockImplementationOnce(() => {
+        return new Promise((resolve) => resolve({ statusCode: 200 }))
+      })
+
+      const { success } = await Jane.ensureExternalUserExists({
+        email: 'test@test.com',
+        external_id: 'test-external-user-id',
+        pool_id: 'test-pool-id',
+        user_attributes: {
+          test_attribute: 'test-value'
+        }
+      })
+
+      expect(success).toBe(true)
+    })
+
+    test('returns invalid with an error message when the status code is 4xx', async () => {
+      jest.spyOn(apiService, 'post').mockImplementationOnce(() => {
+        return new Promise((resolve) =>
+          resolve({
+            statusCode: 404,
+            statusMessage: 'Not Found'
+          })
+        )
+      })
+
+      const { success, errorMessage } = await Jane.ensureExternalUserExists({
+        email: 'test@test.com',
+        external_id: 'test-external-user-id',
+        pool_id: 'test-pool-id',
+        user_attributes: {
+          test_attribute: 'test-value'
+        }
+      })
+
+      expect(success).toBe(false)
+      expect(errorMessage).toEqual('Not Found')
+    })
+  })
+
   describe('#getAppClient', () => {
     const exampleAppClient = {
       id: 12,

--- a/examples/javascript/src/pre-signup-lambda/index.mjs
+++ b/examples/javascript/src/pre-signup-lambda/index.mjs
@@ -20,8 +20,20 @@ export const handler = async (event) => {
   console.log(event);
 
   if (event.triggerSource === ADMIN_CREATE_USER) {
-    console.log(`Trigger source matches "${ADMIN_CREATE_USER}", returning.`);
-    return event;
+    const { success, errorMessage } = await Jane.ensureExternalUserExists({
+      pool_id: event.userPoolId,
+      external_id: event.userName,
+      email: userData.email,
+      user_attributes: userData.user_attributes,
+    })
+
+    if (!success) {
+      throw new Error(`ensureExternalUserExists was not successful: ${errorMessage}`)
+    } else {
+      console.log('ensureExternalUserExists successful')
+    }
+
+    return event
   }
 
   const email = event.request.userAttributes.email;


### PR DESCRIPTION
Just what it says!

Adds `ensureExternalUserExists` call to JaneService, and uses it in the `PreSignUp` handler when the event is from `PreSignUp_AdminCreateUser`.